### PR TITLE
Allow entity to have multiple standalone types

### DIFF
--- a/shape.ttl
+++ b/shape.ttl
@@ -49,7 +49,7 @@ dcatapfeeds:PublishedPropertyShape a sh:PropertyShape ;
 
 
 dcatapfeeds:EntityShape a sh:NodeShape ;
-    sh:xone ( dcatap:Catalog_Shape dcatap:Dataset_Shape dcatap:Distribution_Shape dcatap:DataService_Shape dcatap:Agent_Shape dcatap:Kind_Shape dcatap:LicenseDocument_Shape ) .
+    sh:or ( dcatap:Catalog_Shape dcatap:Dataset_Shape dcatap:Distribution_Shape dcatap:DataService_Shape dcatap:Agent_Shape dcatap:Kind_Shape dcatap:LicenseDocument_Shape ) .
 
 dcatap:Kind_Shape a sh:NodeShape ;
     rdfs:label "Kind"@en ;


### PR DESCRIPTION
Related to #16: standalone entities such as Catalog and DataService might be double typed and appear in one update together validating both shapes.